### PR TITLE
Fix build errors on gcc 14.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENDFLAG=
 #ENDFLAG=-static
 
 #FOR RELEASE
-CFLAGSTEMP=-c -Wall -Wno-unused-variable -Wno-unused-but-set-variable -I.
+CFLAGSTEMP=-c -Wall -Wno-unused-variable -Wno-unused-but-set-variable -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -I.
 
 OPTIMIZATION=-O3
 HEADERS=-I


### PR DESCRIPTION
Tried building on `gcc version 14.2.0 (Debian 14.2.0-19)`
but was failing

```
./library/dynamicVectors.c: In function ‘DYNV_VectorGeneric_Init’:
./library/dynamicVectors.c:42:32: error: assignment to ‘void (*)(void *, int,  void (*)(void *))’ from incompatible pointer type ‘void (*)(DYNV_VectorGenericDataType *, int,  void (*)(void *))’ {aka ‘void (*)(struct DYNV_VectorGenericDataStruct *, int,  void (*)(void *))’} [-Wincompatible-pointer-types]
   42 |     TheVectorGeneric->DeleteAt = &DYNV_VectorGeneric_DeleteAt;

  ...

ftpData.c: In function ‘setRandomicPort’:
ftpData.c:287:14: error: implicit declaration of function ‘isPortInUse’ [-Wimplicit-function-declaration]
  287 |         if (!isPortInUse(randomicPort))
      |              ^~~~~~~~~~~
ftpData.c: In function ‘writeListDataInfoToSocket’:
ftpData.c:434:46: warning: the comparison will always evaluate as ‘false’ for the address of ‘lastModifiedDataString’ will never be NULL [-Waddress]
  434 |                 ,data.lastModifiedDataString == NULL? "Unknown" : data.lastModifiedDataString
      |  

```